### PR TITLE
Fix backup command syntax and improve database restore method

### DIFF
--- a/app/Http/Controllers/DatabaseController.php
+++ b/app/Http/Controllers/DatabaseController.php
@@ -33,7 +33,7 @@ class DatabaseController extends Controller
         // Backup database
         // $exit_code = Artisan::call('backup:run --only-db --disable-notifications');
 
-        $output = shell_exec('cd '.base_path().' && php artisan backup:run --only-db --disable-notifications 2>&1');
+        $output = shell_exec('cd ' . base_path() . ' && php artisan backup:run -n --only-db --disable-notifications 2>&1');
 
         // Check if the backup was successful
 

--- a/app/Http/Controllers/DatabaseController.php
+++ b/app/Http/Controllers/DatabaseController.php
@@ -155,20 +155,9 @@ class DatabaseController extends Controller
                 // Execute SQL restore with foreign key checks disabled
                 DB::unprepared('SET FOREIGN_KEY_CHECKS=0;');
 
-                // Split SQL into individual statements and execute
-                $statements = array_filter(
-                    array_map('trim', explode(';', $sql)),
-                    function ($statement) {
-                        return ! empty($statement);
-                    }
-                );
-
-                foreach ($statements as $statement) {
-                    if (! empty($statement)) {
-                        // Statement already has semicolon from split, no need to add
-                        DB::unprepared($statement);
-                    }
-                }
+                // Execute entire SQL file in one go to avoid splitting inside values
+                // (splitting on ';' breaks serialized/quoted values that contain semicolons)
+                DB::unprepared($sql);
 
                 DB::unprepared('SET FOREIGN_KEY_CHECKS=1;');
 


### PR DESCRIPTION
Add a missing flag for silent mode in the backup command and refactor the database restore method to execute the SQL file in one go, preventing issues with serialized values.